### PR TITLE
Orka Tekton Release Workflow

### DIFF
--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -3,8 +3,8 @@ name: Orka Tekton Release
 on:
   workflow_dispatch:
     inputs:
-      releaseVersion:
-        description: "Release version (for ex. 0.1-latest)"
+      imageTag:
+        description: "Image tag to release (for ex. 0.1-latest)"
         required: true
 
 env:
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -eux -o pipefail
 
-          IMAGE="$GHCR_REPO:${{ github.event.inputs.releaseVersion }}"
+          IMAGE="$GHCR_REPO:${{ github.event.inputs.imageTag }}"
           RELEASE_IMAGE="$GHCR_REPO:${GITHUB_REF##*/}"
 
           docker pull $IMAGE

--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -1,4 +1,4 @@
-name: Tekton Orka Release
+name: Orka Tekton Release
 
 on:
   workflow_dispatch:
@@ -35,15 +35,15 @@ jobs:
           docker tag $IMAGE $RELEASE_IMAGE
           docker push $RELEASE_IMAGE
 
-      # - name: Post slack message on failure
-      #   if: failure()
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: failure
-      #     mention: channel
-      #     if_mention: always
-      #     text: Unable to release Tekton Orka from ${{github.ref}} branch
-      #     fields: repo,commit,author,message,ref,workflow
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
-      #     MATRIX_CONTEXT: ${{toJson(matrix)}}
+      - name: Post slack message on failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          mention: channel
+          if_mention: always
+          text: Unable to release Tekton Orka from ${{github.ref}} branch
+          fields: repo,commit,author,message,ref,workflow
+        env:
+          SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
+          MATRIX_CONTEXT: ${{toJson(matrix)}}

--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -2,10 +2,10 @@ name: Orka Tekton Release
 
 on:
   workflow_dispatch:
-  inputs:
-    releaseVersion:
-      description: "Release version (for ex. 0.1-latest)"
-      required: true
+    inputs:
+      releaseVersion:
+        description: "Release version (for ex. 0.1-latest)"
+        required: true
   push:
     branches:
       - jk/release-workflow

--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -2,6 +2,13 @@ name: Orka Tekton Release
 
 on:
   workflow_dispatch:
+  inputs:
+    releaseVersion:
+      description: "Release version (for ex. 0.1-latest)"
+      required: true
+  push:
+    branches:
+      - jk/release-workflow
 
 env:
   GHCR_REPO: ghcr.io/macstadium/orka-tekton-runner
@@ -27,23 +34,22 @@ jobs:
         run: |
           set -eux -o pipefail
 
-          RELEASE_VERSION="${GITHUB_REF##*/}"
-          IMAGE="$GHCR_REPO:$RELEASE_VERSION-latest"
-          RELEASE_IMAGE="$GHCR_REPO:$RELEASE_VERSION"
+          IMAGE="$GHCR_REPO:${{ github.event.inputs.releaseVersion }}"
+          RELEASE_IMAGE="$GHCR_REPO:${GITHUB_REF##*/}"
 
           docker pull $IMAGE
           docker tag $IMAGE $RELEASE_IMAGE
           docker push $RELEASE_IMAGE
 
-      - name: Post slack message on failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: failure
-          mention: channel
-          if_mention: always
-          text: Unable to release Tekton Orka from ${{github.ref}} branch
-          fields: repo,commit,author,message,ref,workflow
-        env:
-          SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
-          MATRIX_CONTEXT: ${{toJson(matrix)}}
+      # - name: Post slack message on failure
+      #   if: failure()
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: failure
+      #     mention: channel
+      #     if_mention: always
+      #     text: Unable to release Orka Tekton from ${{github.ref}} branch
+      #     fields: repo,commit,author,message,ref,workflow
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
+      #     MATRIX_CONTEXT: ${{toJson(matrix)}}

--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -6,9 +6,6 @@ on:
       releaseVersion:
         description: "Release version (for ex. 0.1-latest)"
         required: true
-  push:
-    branches:
-      - jk/release-workflow
 
 env:
   GHCR_REPO: ghcr.io/macstadium/orka-tekton-runner
@@ -41,15 +38,15 @@ jobs:
           docker tag $IMAGE $RELEASE_IMAGE
           docker push $RELEASE_IMAGE
 
-      # - name: Post slack message on failure
-      #   if: failure()
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: failure
-      #     mention: channel
-      #     if_mention: always
-      #     text: Unable to release Orka Tekton from ${{github.ref}} branch
-      #     fields: repo,commit,author,message,ref,workflow
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
-      #     MATRIX_CONTEXT: ${{toJson(matrix)}}
+      - name: Post slack message on failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          mention: channel
+          if_mention: always
+          text: Unable to release Orka Tekton from ${{github.ref}} branch
+          fields: repo,commit,author,message,ref,workflow
+        env:
+          SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
+          MATRIX_CONTEXT: ${{toJson(matrix)}}

--- a/.github/workflows/orka-tekton-release.yml
+++ b/.github/workflows/orka-tekton-release.yml
@@ -37,16 +37,3 @@ jobs:
           docker pull $IMAGE
           docker tag $IMAGE $RELEASE_IMAGE
           docker push $RELEASE_IMAGE
-
-      - name: Post slack message on failure
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: failure
-          mention: channel
-          if_mention: always
-          text: Unable to release Orka Tekton from ${{github.ref}} branch
-          fields: repo,commit,author,message,ref,workflow
-        env:
-          SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
-          MATRIX_CONTEXT: ${{toJson(matrix)}}

--- a/.github/workflows/tekton-orka-release.yml
+++ b/.github/workflows/tekton-orka-release.yml
@@ -1,0 +1,46 @@
+name: Tekton Orka Release
+
+env:
+  GHCR_REPO: ghcr.io/macstadium/orka-tekton-runner
+
+jobs:
+  publish:
+    if: contains(github.ref, 'refs/heads/releases/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.ref}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release Tekton Orka package
+        run: |
+          set -eux -o pipefail
+
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          IMAGE="$GHCR_REPO:$RELEASE_VERSION-latest"
+          RELEASE_IMAGE="$GHCR_REPO:$RELEASE_VERSION"
+
+          docker pull $IMAGE
+          docker tag $IMAGE $RELEASE_IMAGE
+          docker push $RELEASE_IMAGE
+
+      # - name: Post slack message on failure
+      #   if: failure()
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: failure
+      #     mention: channel
+      #     if_mention: always
+      #     text: Unable to release Tekton Orka from ${{github.ref}} branch
+      #     fields: repo,commit,author,message,ref,workflow
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}
+      #     MATRIX_CONTEXT: ${{toJson(matrix)}}

--- a/.github/workflows/tekton-orka-release.yml
+++ b/.github/workflows/tekton-orka-release.yml
@@ -1,5 +1,8 @@
 name: Tekton Orka Release
 
+on:
+  workflow_dispatch:
+
 env:
   GHCR_REPO: ghcr.io/macstadium/orka-tekton-runner
 


### PR DESCRIPTION
This release workflow uses the `releaseVeresion` provided in `workflow_dispatch` to pull the specific tekton version, re-tag it with official version, and publish the release image to `ghcr.io/macstadium/orka-tekton-runner`