### PR TITLE
Bump version to 0.2 for all tasks

### DIFF
--- a/tasks/orka-deploy.yaml
+++ b/tasks/orka-deploy.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-deploy
   labels:
-    app.kubernetes.io/version: "master"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Deployment
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -51,7 +51,7 @@ spec:
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:master
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: ssh-key
       type: string
       description: |

--- a/tasks/orka-full.yaml
+++ b/tasks/orka-full.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-full
   labels:
-    app.kubernetes.io/version: "master"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -25,7 +25,7 @@ spec:
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:master
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: cpu-count
       type: string
       description: |

--- a/tasks/orka-init.yaml
+++ b/tasks/orka-init.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-init
   labels:
-    app.kubernetes.io/version: "master"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -26,7 +26,7 @@ spec:
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:master
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: cpu-count
       type: string
       description: |

--- a/tasks/orka-teardown.yaml
+++ b/tasks/orka-teardown.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-teardown
   labels:
-    app.kubernetes.io/version: "master"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -43,7 +43,7 @@ spec:
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:master
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
   steps:
     - name: teardown
       image: $(params.docker-image)


### PR DESCRIPTION
For all tasks:
* Update `app.kubernetes.io/version` to `0.2`
* Update Docker image to `ghcr.io/macstadium/orka-tekton-runner:0.2`