### PR TITLE
OK-2480 - Add toleration patches for 3.0 cluster

### DIFF
--- a/patch-files/patch-configmap-tolerations.yaml
+++ b/patch-files/patch-configmap-tolerations.yaml
@@ -1,0 +1,7 @@
+data:
+  default-pod-template: |
+    tolerations:
+      - effect: NoSchedule
+        key: orka.macstadium.com/namespace-reserved
+        operator: Equal
+        value: orka-default

--- a/patch-files/patch-pod-tolerations.yaml
+++ b/patch-files/patch-pod-tolerations.yaml
@@ -1,0 +1,6 @@
+spec:
+  tolerations:
+    - effect: NoSchedule
+      key: orka.macstadium.com/namespace-reserved
+      operator: Equal
+      value: orka-default


### PR DESCRIPTION
### Summary
With the new orka 3.0 cluster, orka nodes are now moved to the `orka-default` namespace.  Tekton uses the `default` namespace out of the box so we'll need to add the proper `orka.macstadium.com/namespace-reserved` toleration key to the tekton pods so they can be scheduled.

Now on a 3.0 cluster, after installing tekton `kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`:

- `install.sh` now checks the orka version for `3.x`
- if version is `3.x`
  - add the toleration to the current tekton pipeline pods (controller, webhook, etc.)
  - add the toleration to the `default-pod-template` in the tekton configmap which all `taskruns` and `pipelineruns` will use (the pod template is merged with the `default-pod-template` on taskrun/pipelinerun creation)